### PR TITLE
Add a bit more air to the tabs in Firefox 16+

### DIFF
--- a/theme/chrome/browser/browser.css
+++ b/theme/chrome/browser/browser.css
@@ -1,4 +1,3 @@
-
 @import url("chrome://global/skin/");
 
 @namespace url("http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul");
@@ -1583,9 +1582,11 @@ richlistitem[type~="action"][actiontype="switchtab"] > .ac-url-box > .ac-action-
   /*
   padding: 1px 2px 3px;
   */
-  padding: 0 4px 2px 3px;
+  padding: 0 12px 2px 12px;
   min-height: 26px; /* reserve space for the sometimes hidden close button */
+/*
   background-clip: padding-box;
+*/
 }
 
 /* swapped overlap for RTL locales */


### PR DESCRIPTION
Make tabs in Firefox 16+ look consistent with Adwaita by adding more space in front of the favicon and behind the close button.
