### PR TITLE
Fix bug in test-theme.sh

### DIFF
--- a/test-theme.sh
+++ b/test-theme.sh
@@ -3,6 +3,9 @@
 PROFILE=default
 
 source ./make-xpi.sh
-cp adwaita-firefox.xpi ~/.mozilla/firefox/*.${PROFILE}/extensions/{451500c0-902c-11e0-91e4-0800200c9a66}.xpi
+for directory in ~/.mozilla/firefox/*.${PROFILE}
+do
+    cp adwaita-firefox.xpi $directory/extensions/{451500c0-902c-11e0-91e4-0800200c9a66}.xpi
+done
 
 killall firefox firefox-bin &>/dev/null; firefox &


### PR DESCRIPTION
When there is more than one *.default repertory in ~/mozilla/firefox , only one copy of the .xpi is really done.
It's fixed by my patch.
