### PR TITLE
Use system theme menu colors

### DIFF
--- a/theme/chrome/global/menu.css
+++ b/theme/chrome/global/menu.css
@@ -67,10 +67,7 @@ menubar > menu[_moz-menuactive="true"]:not([open]):not([disabled="true"]):not(:-
 }
 
 menubar > menu[open] {
-
-/*  color: -moz-menubarhovertext;*/
-/*  background-color: -moz-menuhover;*/
-  color: #2e3436;
+  color: MenuText;
   background-color: Menu;
   border-radius: 3px 3px 0 0;
 }


### PR DESCRIPTION
These changes allow popup menu's to respect the system menu colors. Looks great with Adwaita still, but now works with dark themes that need lighter text colors.

Overall a more native feel.
