### PR TITLE
RequestPolicy toolbar icons

### DIFF
--- a/theme/chrome/browser/extensions/extensions.css
+++ b/theme/chrome/browser/extensions/extensions.css
@@ -38,6 +38,9 @@
 @import url("chrome://browser/skin/extensions/pinboard-extension.css");
 @import url("chrome://browser/skin/extensions/pocket.css");
 
+/* R */
+@import url("chrome://browser/skin/extensions/requestpolicy.css");
+
 /* S */
 @import url("chrome://browser/skin/extensions/stylish.css");
 

--- a/theme/chrome/browser/extensions/requestpolicy.css
+++ b/theme/chrome/browser/extensions/requestpolicy.css
@@ -1,0 +1,23 @@
+/* RequestPolicy
+ * id: requestpolicy@requestpolicy.com
+ * URL: https://addons.mozilla.org/firefox/addon/requestpolicy/ */
+
+#requestpolicyToolbarButton {
+  list-style-image: url(chrome://symbolic-icons/skin/extensions/requestpolicy.svg) !important;
+}
+
+toolbar[requestpolicyBlocked="true"] #requestpolicyToolbarButton,
+[requestpolicyBlocked="true"] toolbar #requestpolicyToolbarButton {
+  list-style-image: url(chrome://symbolic-icons/skin/extensions/requestpolicy-blocked.svg) !important;
+}
+
+toolbar[requestpolicyPermissive="true"] #requestpolicyToolbarButton,
+[requestpolicyPermissive="true"] toolbar #requestpolicyToolbarButton {
+  list-style-image: url(chrome://symbolic-icons/skin/extensions/requestpolicy.svg) !important;
+  opacity: .5;
+}
+
+#requestpolicyToolbarButton[cui-areatype="menu-panel"] .toolbarbutton-icon,
+toolbarpaletteitem[place="palette"] > #requestpolicyToolbarButton .toolbarbutton-icon {
+  opacity: .6;
+}

--- a/theme/chrome/symbolic-icons/extensions/requestpolicy-blocked.svg
+++ b/theme/chrome/symbolic-icons/extensions/requestpolicy-blocked.svg
@@ -1,0 +1,15 @@
+<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" version="1.1" width="16" height="16" viewBox="0 0 16 16">
+  <metadata>
+    <rdf:RDF>
+      <cc:Work rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+        <dc:title/>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs/>
+  <g transform="translate(1.14,1)"/>
+  <path d="m 2.6 11.1 c 0 0 0.9 -0.8 2.6 -0.8 2.1 0 3.7 1.5 5.5 1.5 1.5 0 2.6 -0.7 3.2 -1.3 0.2 -0.2 0.3 -0.5 0.3 -0.8 V 2.6 c 0 -0.4 -0.2 -0.6 -0.6 -0.6 -0.2 0 -0.4 0.1 -0.6 0.3 -0.2 0.2 -1 0.8 -2.7 0.8 -1.6 0 -2.9 -1.5 -4.9 -1.5 -2 0 -2.8 0.6 -2.8 0.6 V 1.7 c 0 -0.4 -0.3 -0.7 -0.7 -0.7 -0.4 0 -0.7 0.3 -0.7 0.7 v 12.5 c 0 0.4 0.3 0.7 0.7 0.7 0.4 0 0.7 -0.3 0.7 -0.7 v -3.2 z m 1.2 -7.2 v 4.7 c 0 0.3 -0.3 0.6 -0.6 0.6 -0.3 0 -0.6 -0.3 -0.6 -0.6 l 0 -4.7 c 0 -0.3 0.3 -0.6 0.6 -0.6 0.3 0 0.6 0.3 0.6 0.6 z" style="fill:#2e3436"/>
+  <path d="m 12.5 9 c -1.9 0 -3.5 1.6 -3.5 3.5 0 1.9 1.6 3.5 3.5 3.5 1.9 0 3.5 -1.6 3.5 -3.5 0 -1.9 -1.6 -3.5 -3.5 -3.5 z m -2.5 3 5 0 0 1 -5 0 0 -1 z" style="color:#bebebe;fill:#ef2929;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.90939796;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
+</svg>

--- a/theme/chrome/symbolic-icons/extensions/requestpolicy.svg
+++ b/theme/chrome/symbolic-icons/extensions/requestpolicy.svg
@@ -1,0 +1,14 @@
+<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" version="1.1" width="16" height="16" viewBox="0 0 16 16">
+  <metadata>
+    <rdf:RDF>
+      <cc:Work rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+        <dc:title/>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs/>
+  <g transform="translate(1.14,1)"/>
+  <path d="m 2.6 11.1 c 0 0 0.9 -0.8 2.6 -0.8 2.1 0 3.7 1.5 5.5 1.5 1.5 0 2.6 -0.7 3.2 -1.3 0.2 -0.2 0.3 -0.5 0.3 -0.8 V 2.6 c 0 -0.4 -0.2 -0.6 -0.6 -0.6 -0.2 0 -0.4 0.1 -0.6 0.3 -0.2 0.2 -1 0.8 -2.7 0.8 -1.6 0 -2.9 -1.5 -4.9 -1.5 -2 0 -2.8 0.6 -2.8 0.6 V 1.7 c 0 -0.4 -0.3 -0.7 -0.7 -0.7 -0.4 0 -0.7 0.3 -0.7 0.7 v 12.5 c 0 0.4 0.3 0.7 0.7 0.7 0.4 0 0.7 -0.3 0.7 -0.7 v -3.2 z m 1.2 -7.2 v 4.7 c 0 0.3 -0.3 0.6 -0.6 0.6 -0.3 0 -0.6 -0.3 -0.6 -0.6 l 0 -4.7 c 0 -0.3 0.3 -0.6 0.6 -0.6 0.3 0 0.6 0.3 0.6 0.6 z" style="fill:#2e3436"/>
+</svg>


### PR DESCRIPTION
Added toolbar icons for [RequestPolicy addon](https://addons.mozilla.org/firefox/addon/requestpolicy/).
![Preview](https://cloud.githubusercontent.com/assets/1756198/2872954/42645f3e-d385-11e3-85e5-85a9277af0f7.png)
Flag icon from WPZOOM Developer Icon Set with minor changes.
