### PR TITLE
Add symbolic icons to page context menu (#279)

### DIFF
--- a/theme/shared/browser/content-contextmenu.svg
+++ b/theme/shared/browser/content-contextmenu.svg
@@ -14,16 +14,18 @@ use:not(:target) {
 }
 
 use {
-  color: menutext;
-  fill: menutext;
+  color: MenuText;
+  fill: MenuText;
 }
 
 use[id$="-active"] {
+  color: -moz-menuhovertext;
   fill: -moz-menuhovertext;
 }
 
 use[id$="-disabled"] {
-  fill: graytext;
+  color: GrayText;
+  fill: GrayText;
 }
 </style>
 <defs style="display:none">


### PR DESCRIPTION
#279 Tested in Firefox 33.0 and 35.0a2
