### PR TITLE
Add greyscale filter (#281)

### DIFF
--- a/extension/chrome/skin/inactive-state.css
+++ b/extension/chrome/skin/inactive-state.css
@@ -169,7 +169,7 @@ notification .messageImage:-moz-window-inactive {
 
 #main-window:-moz-window-inactive .tab-throbber,
 #main-window:-moz-window-inactive .tab-icon-image {
-  filter: url(chrome://mozapps/skin/extensions/extensions.svg#greyscale);
+  filter: url(chrome://global/skin/filters.svg#greyscale);
   opacity: 0.5;
 }
 
@@ -184,7 +184,7 @@ notification .messageImage:-moz-window-inactive {
 /* ::::: browser/searchbar.css ::::: */
 
 .searchbar-engine-image:-moz-window-inactive {
-  filter: url(chrome://mozapps/skin/extensions/extensions.svg#greyscale);
+  filter: url(chrome://global/skin/filters.svg#greyscale);
   opacity: 0.5;
 }
 

--- a/theme/shared/global/filters.svg
+++ b/theme/shared/global/filters.svg
@@ -14,4 +14,7 @@
     <feGaussianBlur result="Shadow" in="offOut" stdDeviation="0" />
     <feBlend in="WhiteIcon" in2="Shadow" mode="normal" />
   </filter>
+  <filter id="greyscale">
+    <feColorMatrix type="saturate" values="0"/>
+  </filter>
 </svg>


### PR DESCRIPTION
I put the Mozilla greyscale filter into the theme because it was missing in Fx 36. This applies to tab and search bar favicons in inactive windows. Fixes #281.
