### PR TITLE
Fix newtab pin buttons (#165)

### DIFF
--- a/theme/shared/browser/newtab/newTab.css
+++ b/theme/shared/browser/newtab/newTab.css
@@ -240,14 +240,19 @@
   background: url(chrome://symbolic-icons/skin/pin_white.svg) no-repeat center;
   background-color: rgba(0,0,0,0.25);
   border-radius: 50%;
-}
-
-.newtab-control-pin[pinned] {
-  background-color: rgba(0,0,0,0.55);
   -moz-transform: rotate(30deg);
 }
 
-.newtab-control-pin[pinned]:hover {
+.newtab-control-pin:hover {
+  background-color: rgba(0,0,0,0.85);
+}
+
+.newtab-site[pinned] .newtab-control-pin {
+  background-color: rgba(0,0,0,0.55);
+  -moz-transform: rotate(0);
+}
+
+.newtab-site[pinned] .newtab-control-pin:hover {
   background-color: rgba(0,0,0,0.85);
 }
 


### PR DESCRIPTION
Fixes #165.
![newtab-pin](https://cloud.githubusercontent.com/assets/107189/5339949/16912212-7ee7-11e4-9b84-24e9e6313529.png)

IMO hover states of pin and close button should match (opacity 0.85).
