### PR TITLE
Use "go" icon in searchbar instead of another magnifying glass

### DIFF
--- a/theme/shared/browser/searchbar.css
+++ b/theme/shared/browser/searchbar.css
@@ -79,7 +79,7 @@ toolbar[brighttext] .searchbar-search-button-container:active {
 /* Search go button */
 
 .search-go-button {
-  list-style-image: url(chrome://symbolic-icons/skin/edit-find.svg);
+  list-style-image: url(chrome://symbolic-icons/skin/go-next.svg);
   height: 26px;
   min-width: 26px;
   padding: 5px;


### PR DESCRIPTION
When the search box has text, there are two magnifying glass icons, I think this looks bad...

![screenshot from 2016-04-20 22-07-36](https://cloud.githubusercontent.com/assets/4677622/14698625/807a7a9c-0745-11e6-9a60-69a8be914c4c.png)

 The search box would look better using the "go" icon that the URL bar uses instead...

![screenshot from 2016-04-20 22-21-41](https://cloud.githubusercontent.com/assets/4677622/14698737/64cfe074-0746-11e6-9568-2b53b612e98e.png)