### PR TITLE
Update icon for New Tab

### DIFF
--- a/theme/shared/symbolic-icons/tab-new.svg
+++ b/theme/shared/symbolic-icons/tab-new.svg
@@ -1,21 +1,158 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns="http://www.w3.org/2000/svg" sodipodi:docname="tab-new-symbolic.svg" height="16" width="16" version="1.1" xmlns:cc="http://creativecommons.org/ns#" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" inkscape:version="0.48.1 r9760" xmlns:dc="http://purl.org/dc/elements/1.1/">
-<metadata>
-<rdf:RDF>
-<cc:Work rdf:about="">
-<dc:format>image/svg+xml</dc:format>
-<dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-<dc:title>Gnome Symbolic Icon Theme</dc:title>
-</cc:Work>
-</rdf:RDF>
-</metadata>
-<sodipodi:namedview inkscape:zoom="1" borderopacity="1" inkscape:current-layer="layer12" inkscape:cx="-64.320577" inkscape:guide-bbox="true" inkscape:snap-grids="true" inkscape:snap-bbox-midpoints="false" inkscape:object-paths="false" inkscape:window-maximized="0" inkscape:snap-bbox="true" showgrid="false" inkscape:snap-nodes="true" inkscape:snap-global="true" showguides="true" bordercolor="#666666" inkscape:window-x="2804" inkscape:window-y="77" objecttolerance="10" inkscape:object-nodes="false" inkscape:snap-others="false" inkscape:window-width="1226" inkscape:pageopacity="1" inkscape:snap-to-guides="true" inkscape:pageshadow="2" guidetolerance="10" pagecolor="#555753" gridtolerance="10" inkscape:bbox-paths="false" inkscape:cy="-84.01275" inkscape:window-height="967" showborder="false">
-<inkscape:grid visible="true" enabled="true" spacingy="1px" spacingx="1px" snapvisiblegridlinesonly="true" type="xygrid" empspacing="2"/>
-</sodipodi:namedview>
-<title>Gnome Symbolic Icon Theme</title>
-<g inkscape:label="actions" transform="translate(-120 -686)" inkscape:groupmode="layer" fill="ButtonText">
-<path style="color:ButtonText" inkscape:connector-curvature="0" d="m123 688c-0.88358 0-2 1.1069-2 2v8h-1v2h3v-10h10v10h3v-2h-1v-8c0-0.89314-1.1164-2-2-2z" sodipodi:nodetypes="ssccccccccccsss"/>
-<rect y="694" width="6" x="125" height="2"/>
-<rect y="-129" width="6" x="692" transform="rotate(90)" height="2"/>
-</g>
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   sodipodi:docname="tab-new.svg"
+   height="16"
+   width="16"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   id="svg2">
+  <defs
+     id="defs20">
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient19282"
+       gradientTransform="matrix(-2.7365795,0.28202934,-0.18908311,-0.99988321,239.54008,-879.45557)">
+      <stop
+         style="stop-color:#666666;stop-opacity:1;"
+         offset="0"
+         id="stop19284" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata4">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Gnome Symbolic Icon Theme</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     inkscape:zoom="16"
+     borderopacity="1"
+     inkscape:current-layer="g12"
+     inkscape:cx="7.0711774"
+     inkscape:guide-bbox="true"
+     inkscape:snap-grids="true"
+     inkscape:snap-bbox-midpoints="false"
+     inkscape:object-paths="false"
+     inkscape:window-maximized="0"
+     inkscape:snap-bbox="true"
+     showgrid="false"
+     inkscape:snap-nodes="true"
+     inkscape:snap-global="true"
+     showguides="true"
+     bordercolor="#666666"
+     inkscape:window-x="285"
+     inkscape:window-y="107"
+     objecttolerance="10"
+     inkscape:object-nodes="false"
+     inkscape:snap-others="false"
+     inkscape:window-width="1226"
+     inkscape:pageopacity="1"
+     inkscape:snap-to-guides="true"
+     inkscape:pageshadow="2"
+     guidetolerance="10"
+     pagecolor="#555753"
+     gridtolerance="10"
+     inkscape:bbox-paths="false"
+     inkscape:cy="3.9648011"
+     inkscape:window-height="704"
+     showborder="false"
+     id="namedview6">
+    <inkscape:grid
+       visible="true"
+       enabled="true"
+       spacingy="1px"
+       spacingx="1px"
+       snapvisiblegridlinesonly="true"
+       type="xygrid"
+       empspacing="2"
+       id="grid8" />
+    <sodipodi:guide
+       position="4.8125,13.9375"
+       orientation="0,1"
+       id="guide4180" />
+    <sodipodi:guide
+       position="0.0625,6.5"
+       orientation="1,0"
+       id="guide4182" />
+  </sodipodi:namedview>
+  <title
+     id="title10">Gnome Symbolic Icon Theme</title>
+  <g
+     inkscape:label="actions"
+     transform="translate(-120 -686)"
+     inkscape:groupmode="layer"
+     fill="ButtonText"
+     id="g12">
+    <g
+       id="g4168"
+       transform="translate(120.0625,685.0625)"
+       style="fill:#000000;fill-opacity:1">
+      <g
+         transform="translate(-120.00019,-806)"
+         style="display:inline;fill:#000000;fill-opacity:1"
+         inkscape:label="status"
+         id="layer9" />
+      <g
+         transform="translate(-120.00019,-806)"
+         style="display:inline;fill:#000000;fill-opacity:1"
+         inkscape:label="devices"
+         id="layer10" />
+      <g
+         transform="translate(-120.00019,-806)"
+         inkscape:label="apps"
+         id="layer11"
+         style="fill:#000000;fill-opacity:1" />
+      <g
+         transform="translate(-120.00019,-806)"
+         style="display:inline;fill:#000000;fill-opacity:1"
+         inkscape:label="places"
+         id="layer13" />
+      <g
+         transform="translate(-120.00019,-806)"
+         inkscape:label="mimetypes"
+         id="layer14"
+         style="fill:#000000;fill-opacity:1" />
+      <g
+         transform="translate(-120.00019,-806)"
+         style="display:inline;fill:#000000;fill-opacity:1"
+         inkscape:label="emblems"
+         id="layer15" />
+      <g
+         transform="translate(-120.00019,-806)"
+         style="display:inline;fill:#000000;fill-opacity:1"
+         inkscape:label="emotes"
+         id="g71291" />
+      <g
+         transform="translate(-120.00019,-806)"
+         style="display:inline;fill:#000000;fill-opacity:1"
+         inkscape:label="categories"
+         id="g4953" />
+      <g
+         transform="translate(-120.00019,-806)"
+         style="display:inline;fill:#000000;fill-opacity:1"
+         inkscape:label="actions"
+         id="layer12">
+        <path
+           style="display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;enable-background:new"
+           sodipodi:nodetypes="csscccccsccscccccccccccccc"
+           id="path3027-5"
+           d="m 124.0002,809 c 0,0 -2.00001,0 -2.00001,2 l 0,7 c 0,1 -0.99999,1 -0.99999,1 l -1.00001,0 0,2 16.00001,0 0,-2 -1.00001,0 c 0,0 -1,0 -1,-1 l 0,-7 c 0,0 0,-2 -2,-2 z m 2.99999,3 2.00001,0 0,2 2,0 0,2 -2,0 0,2 -2.00001,0 0,-2 -2,0 0,-2 2,0 z"
+           inkscape:connector-curvature="0" />
+      </g>
+    </g>
+  </g>
 </svg>


### PR DESCRIPTION
I've updated the New Tab icon, to be in pair with the one use in Epiphany (GNOME Web).